### PR TITLE
[Fix] Additional hCaptcha fixes and disabled the broken upstream dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Karlsen Faucet
 
 Miniature Karlsen faucet website based on [Karlsen Wallet](https://github.com/karlsen-network/node-karlsen-wallet)
-framework.
+framework. The faucet can be run on single or multiple networks.
+In case you run it on multiple networks it will use the same
+seed phrase for all together.
 
 ## Setup Karlsend
 
@@ -29,60 +31,35 @@ cd karlsend/cmd/karlsenminer
 karlsenminer --miningaddr=karlsentest:qpuyhaxz2chn3lsvf8g7q5uvaezpp5m7pyny4k8tyq --mine-when-not-synced --testnet
 ```
 
+## Configuration
+
+You need to have a hCaptcha subscription. You can create a free one
+at: https://www.hcaptcha.com/
+
+Once you have created it copy the `sitekey` and `secret` into
+`config/karlsen-faucet.conf` file.
+
+Lastly you need to create a file `.seeds` with the 12-word seed
+phrase of a wallet to disable address derivation. This is optional
+but recommended if you run the faucet on a secure and privately
+owned system.
+
+It is highly recommended to run the faucet behind a reverse proxy
+like NGINX and add the following header into your proxy
+configuration:
+
+```
+proxy_set_header X-Real-IP $remote_addr;
+```
+
+It will ensure that single IP addresses cannot empty the faucet and
+limit their amount in the 24 hour timeframe.
+
 ## Running
 
 ```
 git clone https://github.com/karlsen-network/node-karlsen-faucet
 cd node-karlsen-faucet
 npm install
-node karlsen-faucet
+node karlsen-faucet.js --testnet --host 0.0.0.0 --limit 100 --rpc 127.0.0.1:42210
 ```
-
-## Development Environment
-
-To setup development environment for debugging `karlsen-wallet` and
-`karlsencore-lib` modules:
-
-### Setup TypeScript
-
-```
-npm install -g typescript
-tsc -v
-```
-
-`tsc` should yield 4.0.5 or higher.
-
-### Clone and setup repositories
-
-git clone https://github.com/karlsen-network/node-karlsen-faucet
-git clone https://github.com/karlsen-network/node-karlsen-wallet
-git clone https://github.com/karlsen-network/node-karlsen-core-lib
-cd node-karlsen-core-lib
-npm link
-cd ..
-cd node-karlsen-wallet
-npm link
-npm link karlsen-core-lib
-cd ..
-cd node-karlsen-faucet
-npm install
-npm link karlsen-wallet
-cd ..
-
-Terminal 1:
-
-```
-cd node-karlsen-wallet
-tsc --watch
-```
-
-Terminal 2:
-
-```
-cd node-karlsen-faucet
-node karlsen-faucet
-```
-
-`node karlsen-faucet` will attempt to bind to all available networks.
-You can use `--devnet` and `--testnet` flags to have it bind to a
-single network.

--- a/http/style/main.css
+++ b/http/style/main.css
@@ -97,10 +97,6 @@ body:not(.flow-theme-light) {
 	--logo-light-display: none;
 }
 
-body:not(.flow-theme-dark) {
-	--logo-dark-display: none;
-}
-
 .main-area {
 	display: flex;
 	flex-direction: row;
@@ -115,17 +111,9 @@ body:not(.flow-theme-dark) {
 	overflow-x: hidden;
 }
 
-.flow-theme-dark .main-area {
-	--flow-input-bg: #161927;
-}
-
 .flow-theme-light .menu li.active {
 	--fa-icon-color: #FFFFFF;
 	color: #FFFFFF;
-}
-
-.logo.dark {
-	display: var(--logo-dark-display, initial)
 }
 
 .logo.light {
@@ -178,7 +166,8 @@ flow-select.no-h-margin {
 	margin-right: 0px;
 }
 
-body.flow-theme-light {
+body.flow-theme-light,
+body.flow-theme-dark {
 	--color-l-offset: 0%;
 	--color-l-offset-more: 48%;
 	--color-box-active-border-color: #b1b1b1;
@@ -374,9 +363,9 @@ flow-dialog.custom .amount {
 }
 
 flow-dialog {
-	--flow-btn-hover-border-color: var(--flow-primary-color);
-	--flow-btn-hover-primary-bg-color: white;
-	--flow-btn-hover-primary-color: var(--flow-primary-color);
+	--flow-btn-hover-border-color: #808080;
+	--flow-btn-hover-primary-bg-color: #808080;
+	--flow-btn-hover-primary-color: #000000;
 }
 
 flow-dialog.custom .api-error {


### PR DESCRIPTION
With PR #1 we've added Karlsen network support but unfortunately in `flow-utils` the `siteverify` URL is hardcoded to redirect requests to reCAPTCHA regardless of which hCaptcha implementation is used. 🤦 To fix it in dirty Node.js style it has been overwritten by `validatehCaptcha`.

Also the upstream Kaspa faucet had some partial - not yet fully working - dark mode. In some situations it decides based on some browser environment which mode to select but without selecting the proper mode for the captcha and some weird input coloring. We've remapped the dark mode to light mode and will re-enable it at a later time.

Documentation instructions have been updated and NGINX reverse proxy recommendation has been added.